### PR TITLE
Fix compile:dynamic

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "compile:js": "npm run lint:js && mkdir -p public && browserify src/js/index.js > /tmp/bundle.js && mv /tmp/bundle.js public/bundle.js",
     "compile:css": "mkdir -p public && stylus src/css/index.styl -o public/index.css",
     "compile:html": "mkdir -p public && pug src/html/pages/ --out public -O \"$(scripts/data_cache)\" --hierarchy",
-    "compile:dynamic": "mkdir -p public/posts && src/dynamic src/html/post.pug \"$(scripts/data_cache)\"",
+    "compile:dynamic": "mkdir -p public/posts && scripts/data_cache | src/dynamic src/html/post.pug",
     "compile:assets": "mkdir -p public && cp -R src/assets public/",
     "cache:clear": "if [[ -f .data ]]; then rm .data; fi",
     "lint:js": "standard src/js/**/*.js --verbose | snazzy",

--- a/src/dynamic
+++ b/src/dynamic
@@ -2,12 +2,24 @@
 
 var pug = require('pug');
 var fs = require('fs');
+var readline = require('readline');
 
+var data;
 var tpl = process.argv[2];
-var data = process.argv[3];
+var rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  terminal: false
+});
 
-console.log(data.data)
-for (var post in data.data) {
-  console.log(data.data[post]);
-  fs.writeFileSync(`public/posts/${data.data[post].title.toLowerCase().replace(' ', '-')}.html`, pug.renderFile(tpl, post));
-};
+rl.on('line', (input) => {
+  data = input
+});
+
+rl.on('close', () => {
+  data = JSON.parse(data)
+  for (var post in data.data) {
+    post = data.data[post]
+    fs.writeFileSync(`public/posts/${post.title.toLowerCase().replace(' ', '-')}.html`, pug.renderFile(tpl, post));
+  };
+});


### PR DESCRIPTION
Because sometimes our data can be HUGE.. well at least a lot bigger than the predefined `ulimit` of any OS, I've switched passing our data from `scripts/data_cache`  as a param to passing the data via I/O redirection using a pipe.

```bash
# New npm script (npm run compile:dynamic)
scripts/data_cache | src/templates src/html/post.pug
```