### PR TITLE
Move any dirs within assets to root public

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "compile:html": "npm run compile:html:pages && npm run compile:html:templates",
     "compile:html:pages": "mkdir -p public && pug src/html/pages/ --out public -O \"$(scripts/data_cache)\" --hierarchy",
     "compile:html:templates": "mkdir -p public && cat \"$(scripts/data_cache)\" | src/templates",
-    "compile:assets": "mkdir -p public && cp -R src/assets public/",
+    "compile:assets": "mkdir -p public && cp -R src/assets/ public/",
     "cache:clear": "if [[ -f .data ]]; then rm .data; fi",
     "lint:js": "standard src/js/**/*.js --verbose | snazzy",
     "serve": "browser-sync start --server --ss public --files public --xip"


### PR DESCRIPTION
I noticed that my `img` within `assets` was being placed into `public/assets/img`. I think it would be better in `public/img`. What are your thoughts on this?